### PR TITLE
Start using Jenkinsfile to define build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,8 +13,17 @@ timestamps {
 		}
 
 		buildConnector {
-			// don't override anything yet, like
-			// nodeVersion = '4.7.3'
+			// don't override anything yet, like:
+
+			// nodeVersion = '4.7.3' // Updating this requires we set up the desired
+			// version of Node.JS on our Jenkins master as a "tool" first
+
+			// updateJIRA = true // Defaults to true if this build isn't a PR
+
+			// publish = true // Defaults to true if this build isn't a PR,
+			// but you could do something like:
+			// publish = env.BRANCH_NAME.equals('master')
+			// to only publish on master branch builds.
 		}
 	}
 }


### PR DESCRIPTION
This is a placeholder Jenkinsfile to generate Jenkins builds for this repo. The step which sets up the config/local.js file should be updated to use some test credentials for twilio when running `npm test`.